### PR TITLE
fix: requeue manual deployments when bakeStatus is Deploying

### DIFF
--- a/internal/controller/rollout_controller.go
+++ b/internal/controller/rollout_controller.go
@@ -312,13 +312,17 @@ func (r *RolloutReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			"hasManualDeployment", r.hasManualDeployment(&rollout),
 			"hasBakeTimeConfig", r.hasBakeTimeConfiguration(&rollout))
 
-		// Check if the current deployment is the wanted version and bake time is in progress
+		// Check if the current deployment is the wanted version and bake is active.
+		// Accept both Deploying and InProgress: on the reconcile where handleBakeTime
+		// transitions Deploying→InProgress, the refetched rollout may still show
+		// Deploying due to informer cache lag — we must still schedule a requeue.
 		if len(rollout.Status.History) > 0 &&
 			rollout.Status.History[0].Version.Tag == *wantedRelease &&
 			rollout.Status.History[0].BakeStatus != nil &&
-			*rollout.Status.History[0].BakeStatus == rolloutv1alpha1.BakeStatusInProgress {
+			(*rollout.Status.History[0].BakeStatus == rolloutv1alpha1.BakeStatusInProgress ||
+				*rollout.Status.History[0].BakeStatus == rolloutv1alpha1.BakeStatusDeploying) {
 			requeueAfter := r.calculateRequeueTime(&rollout)
-			log.Info("Manual deployment already deployed with in-progress bake time, requeuing to monitor", "requeueAfter", requeueAfter)
+			log.Info("Manual deployment bake active, requeuing to monitor", "bakeStatus", *rollout.Status.History[0].BakeStatus, "requeueAfter", requeueAfter)
 			return ctrl.Result{RequeueAfter: requeueAfter}, nil
 		} else {
 			log.Info("No requeue needed for manual deployment",

--- a/internal/controller/rollout_controller_test.go
+++ b/internal/controller/rollout_controller_test.go
@@ -2496,6 +2496,43 @@ var _ = Describe("Rollout Controller", func() {
 				Expect(result.RequeueAfter).To(BeNumerically("<=", 5*time.Minute))
 			})
 
+			It("should requeue manual deployment when bake is still Deploying (health checks not healthy)", func() {
+				By("Setting wantedVersion and bake time")
+				rollout.Spec.WantedVersion = k8sptr.To(version0_1_0)
+				Expect(k8sClient.Update(ctx, rollout)).To(Succeed())
+
+				By("Pushing the wanted version to ImagePolicy")
+				imagePolicy.Status.LatestRef = &imagev1beta2.ImageRef{
+					Tag: version0_1_0,
+				}
+				Expect(k8sClient.Status().Update(ctx, imagePolicy)).To(Succeed())
+
+				By("First reconcile: deploys wanted version, bake status = Deploying (health checks not healthy yet)")
+				controllerReconciler := &RolloutReconciler{Client: k8sClient, Scheme: k8sClient.Scheme(), Clock: fakeClock}
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Verifying deployment created with Deploying status (health checks not healthy)")
+				rollout := &rolloutv1alpha1.Rollout{}
+				Expect(k8sClient.Get(ctx, typeNamespacedName, rollout)).To(Succeed())
+				Expect(rollout.Status.History).To(HaveLen(1))
+				Expect(rollout.Status.History[0].Version.Tag).To(Equal(version0_1_0))
+				Expect(*rollout.Status.History[0].BakeStatus).To(Equal(rolloutv1alpha1.BakeStatusDeploying))
+				Expect(rollout.Status.History[0].BakeStartTime).To(BeNil())
+
+				By("Second reconcile: health checks still not healthy, bake stays Deploying")
+				// Health check exists but has no LastChangeTime, so bake can't start.
+				// This simulates the informer-cache stale read: handleBakeTime runs but can't
+				// transition to InProgress, and the refetched rollout still shows Deploying.
+				// The manual deployment monitor must still schedule a requeue.
+				result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: typeNamespacedName})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Verifying requeue is scheduled (not zero) so bake monitoring continues")
+				Expect(result.RequeueAfter).To(BeNumerically(">", 0),
+					"manual deployment with Deploying bake must requeue to keep monitoring even before bake starts")
+			})
+
 			It("should cancel existing deploying bake when deploying new version", func() {
 				By("Pushing and deploying an initial image")
 				imagePolicy.Status.LatestRef = &imagev1beta2.ImageRef{


### PR DESCRIPTION
## Summary

- **Bug**: When `handleBakeTime` transitions a manual deployment from `Deploying` → `InProgress`, the refetched rollout may still show `Deploying` due to informer cache lag. The manual deployment monitor only checked `== BakeStatusInProgress`, so it logged "No requeue needed" and dropped the 10s requeue — causing a 60+ second gap before bake started.
- **Fix**: Accept both `BakeStatusDeploying` and `BakeStatusInProgress` in the condition at `rollout_controller.go:319`, so the controller continuously polls (every 10s) from deployment until health checks clear and bake starts.
- **Test**: Added `"should requeue manual deployment when bake is still Deploying (health checks not healthy)"` which failed before the fix and passes after.

## Test plan

- [ ] `make test` passes in rollout-controller
- [ ] On cluster: set `wantedVersion` to trigger manual deploy, verify "Manual deployment bake active, requeuing to monitor" appears in logs with `bakeStatus: "Deploying"` and `requeueAfter: "10s"` immediately after deployment
- [ ] Bake starts within ~10s of health checks clearing (vs 65+ seconds before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)