### PR TITLE
fix: attribute automatic deployments to System, not stale deploy-user

### DIFF
--- a/internal/controller/rollout_controller.go
+++ b/internal/controller/rollout_controller.go
@@ -1382,15 +1382,24 @@ func (r *RolloutReconciler) deployRelease(ctx context.Context, rollout *rolloutv
 			log.Error(err, "Failed to patch rollout to clear force deploy annotations")
 			return err
 		}
-	} else if r.hasManualDeployment(rollout) {
-		// Clear deploy-message and deploy-user annotations when WantedVersion was used
-		patch := client.MergeFrom(rollout.DeepCopy())
-		delete(rollout.Annotations, "rollout.kuberik.com/deploy-message")
-		delete(rollout.Annotations, "rollout.kuberik.com/deploy-user")
+	} else if rollout.Annotations != nil {
+		// Clear the one-shot deploy-message/deploy-user intent annotations after any
+		// deployment, not just manual ones. They are consumed by this deployment; an
+		// automatic deploy only runs when no manual intent (WantedVersion/force-deploy)
+		// exists, so any deploy-user/deploy-message still set at that point is stale
+		// (e.g. left over from clearing a version pin). Leaving them set would
+		// misattribute or mislabel subsequent automatic deployments.
+		_, hasMessage := rollout.Annotations["rollout.kuberik.com/deploy-message"]
+		_, hasUser := rollout.Annotations["rollout.kuberik.com/deploy-user"]
+		if hasMessage || hasUser {
+			patch := client.MergeFrom(rollout.DeepCopy())
+			delete(rollout.Annotations, "rollout.kuberik.com/deploy-message")
+			delete(rollout.Annotations, "rollout.kuberik.com/deploy-user")
 
-		if err := r.Client.Patch(ctx, rollout, patch); err != nil {
-			log.Error(err, "Failed to patch rollout to clear deploy-message and deploy-user annotations")
-			return err
+			if err := r.Client.Patch(ctx, rollout, patch); err != nil {
+				log.Error(err, "Failed to patch rollout to clear deploy-message and deploy-user annotations")
+				return err
+			}
 		}
 	}
 
@@ -2038,10 +2047,14 @@ func (r *RolloutReconciler) getNextHistoryID(rollout *rolloutv1alpha1.Rollout) i
 }
 
 // extractTriggeredByInfo extracts triggered by information from annotations.
-// Returns nil if no user annotation is found (indicating a system-triggered deployment).
+// A deployment is only attributed to a User when it is an actual manual deployment
+// (WantedVersion or force-deploy). The deploy-user annotation is a one-shot intent
+// set by the dashboard; it can linger after non-deploying actions such as clearing a
+// version pin. Reading it unconditionally previously misattributed subsequent
+// automatic deployments to whoever last set the annotation, so automatic deployments
+// are always reported as System regardless of any stale deploy-user annotation.
 func (r *RolloutReconciler) extractTriggeredByInfo(rollout *rolloutv1alpha1.Rollout, isManualDeployment bool) *rolloutv1alpha1.TriggeredByInfo {
-	// Check for user annotation (similar to how we check deploy-message annotation)
-	if rollout.Annotations != nil {
+	if isManualDeployment && rollout.Annotations != nil {
 		if userName, exists := rollout.Annotations["rollout.kuberik.com/deploy-user"]; exists && userName != "" {
 			return &rolloutv1alpha1.TriggeredByInfo{
 				Kind: "User",
@@ -2050,7 +2063,7 @@ func (r *RolloutReconciler) extractTriggeredByInfo(rollout *rolloutv1alpha1.Roll
 		}
 	}
 
-	// If no user annotation found, it's a system-triggered deployment
+	// Automatic deployment (or no user annotation) - system-triggered.
 	return &rolloutv1alpha1.TriggeredByInfo{
 		Kind: "System",
 		Name: "rollout-controller",

--- a/internal/controller/rollout_controller_test.go
+++ b/internal/controller/rollout_controller_test.go
@@ -3854,6 +3854,83 @@ var _ = Describe("Rollout Controller", func() {
 				Expect(updatedRollout.Status.History[0].TriggeredBy.Name).To(Equal("rollout-controller"))
 			})
 
+			It("should record system-triggered deployment and clear a stale deploy-user annotation on automatic deploy", func() {
+				// Regression: a deploy-user annotation can linger after a non-deploying
+				// action such as clearing a version pin (wantedVersion=nil). The next
+				// automatic deployment must NOT be attributed to that user, and the stale
+				// annotation must be cleared so it doesn't keep mislabeling deployments.
+				By("Setting up a rollout with a stale deploy-user/deploy-message but no manual deployment")
+				staleAnnotationRollout := &rolloutv1alpha1.Rollout{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "stale-deploy-user-rollout",
+						Namespace: namespace,
+						Annotations: map[string]string{
+							"rollout.kuberik.com/deploy-user":    "dave@example.com",
+							"rollout.kuberik.com/deploy-message": "Cleared version pin",
+						},
+					},
+					Spec: rolloutv1alpha1.RolloutSpec{
+						ReleasesImagePolicy: corev1.LocalObjectReference{
+							Name: "test-image-policy",
+						},
+					},
+					Status: rolloutv1alpha1.RolloutStatus{
+						AvailableReleases: []rolloutv1alpha1.VersionInfo{
+							{Tag: "1.0.0"},
+						},
+						GatedReleaseCandidates: []rolloutv1alpha1.VersionInfo{
+							{Tag: "1.0.0"},
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, staleAnnotationRollout)).To(Succeed())
+				Expect(k8sClient.Status().Update(ctx, staleAnnotationRollout)).To(Succeed())
+
+				By("Setting up ImagePolicy with releases")
+				var imagePolicy imagev1beta2.ImagePolicy
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      "test-image-policy",
+					Namespace: namespace,
+				}, &imagePolicy)
+				Expect(err).NotTo(HaveOccurred())
+
+				imagePolicy.Status.LatestRef = &imagev1beta2.ImageRef{
+					Tag: "1.0.0",
+				}
+				Expect(k8sClient.Status().Update(ctx, &imagePolicy)).To(Succeed())
+
+				By("Reconciling (automatic deployment) with a stale deploy-user present")
+				controllerReconciler := &RolloutReconciler{
+					Client: k8sClient,
+					Scheme: k8sClient.Scheme(),
+				}
+				_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      "stale-deploy-user-rollout",
+						Namespace: namespace,
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Verifying the automatic deployment is attributed to System, not the stale user")
+				var updatedRollout rolloutv1alpha1.Rollout
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      "stale-deploy-user-rollout",
+					Namespace: namespace,
+				}, &updatedRollout)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(updatedRollout.Status.History).To(HaveLen(1))
+				Expect(updatedRollout.Status.History[0].Version.Tag).To(Equal("1.0.0"))
+				Expect(updatedRollout.Status.History[0].TriggeredBy).NotTo(BeNil())
+				Expect(updatedRollout.Status.History[0].TriggeredBy.Kind).To(Equal("System"))
+				Expect(updatedRollout.Status.History[0].TriggeredBy.Name).To(Equal("rollout-controller"))
+
+				By("Verifying the stale one-shot annotations were cleared")
+				Expect(updatedRollout.Annotations).NotTo(HaveKey("rollout.kuberik.com/deploy-user"))
+				Expect(updatedRollout.Annotations).NotTo(HaveKey("rollout.kuberik.com/deploy-message"))
+			})
+
 			It("should clear deploy-user annotation when force deploy is used", func() {
 				By("Setting up a rollout with force-deploy and deploy-user annotations")
 				clearAnnotationRollout := &rolloutv1alpha1.Rollout{
@@ -5604,7 +5681,10 @@ var _ = Describe("extractTriggeredByInfo", func() {
 		Expect(result.Name).To(Equal("alice@example.com"))
 	})
 
-	It("should return User kind even when isManualDeployment is false but annotation exists", func() {
+	It("should return System kind when isManualDeployment is false even if a (stale) deploy-user annotation exists", func() {
+		// Regression: a deploy-user annotation can linger after a non-deploying action
+		// (e.g. clearing a version pin). Automatic deployments must not be attributed to
+		// that user — they are always System.
 		rollout := &rolloutv1alpha1.Rollout{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
@@ -5616,8 +5696,8 @@ var _ = Describe("extractTriggeredByInfo", func() {
 		result := reconciler.extractTriggeredByInfo(rollout, false)
 
 		Expect(result).NotTo(BeNil())
-		Expect(result.Kind).To(Equal("User"))
-		Expect(result.Name).To(Equal("bob@example.com"))
+		Expect(result.Kind).To(Equal("System"))
+		Expect(result.Name).To(Equal("rollout-controller"))
 	})
 
 	It("should return System kind when deploy-user annotation is not present", func() {


### PR DESCRIPTION
The deploy-user annotation is a one-shot intent set by the dashboard, but it
was read unconditionally by extractTriggeredByInfo and only cleared on manual
deploys. Clearing a version pin (wantedVersion=nil) sets deploy-user without a
manual deployment, so the annotation lingered and every subsequent automatic
deployment was misattributed to whoever last set it (e.g. an "Automatic
deployment" history entry showing TriggeredBy=User/<someone>).

- extractTriggeredByInfo now returns User only for actual manual deployments
  (WantedVersion/force-deploy); automatic deployments are always System,
  regardless of any stale deploy-user annotation.
- Clear the one-shot deploy-user/deploy-message annotations after any deploy,
  not just manual ones, so a leftover annotation can't keep mislabeling
  later deployments.

Update the test that codified the buggy behavior and add a regression test
covering an automatic deploy with a stale deploy-user annotation present.

Co-authored-by: Cursor <cursoragent@cursor.com>
